### PR TITLE
Add homepage field for GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "homepage": "https://<GitHub-username>.github.io/weather-watcher"
 }


### PR DESCRIPTION
## Summary
- define the `homepage` property in `package.json` for CRA's asset paths

## Testing
- `npm install` *(fails: No matching version found for react-testing-library)*
- `npm run build` *(fails: react-scripts not found)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bbda073e48325b48874354cdae3ed